### PR TITLE
FIX#4 Increasing the memory with 256Mb from 1024Mb into 1280Mb fixes the...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant::Config.run do |config|
     # devstack_config.vm.boot_mode = :gui
     devstack_config.vm.network  :hostonly, "10.1.2.44" #:hostonly or :bridged - default is NAT
     devstack_config.vm.host_name = dhostname
-    devstack_config.vm.customize ["modifyvm", :id, "--memory", 1024]
+    devstack_config.vm.customize ["modifyvm", :id, "--memory", 1280]
     devstack_config.ssh.max_tries = 100
 
     devstack_config.vm.provision :puppet do |devstack_puppet|


### PR DESCRIPTION
Slightly to tight memory seems to fail the assignment of the $token variable that results in a problem in the stack.sh executable when it calls glance. Problem was also described here: https://ask.openstack.org/question/2193/devstack-installation-error-on-ubuntu-64/  

Increasing the memory worked also for us here. Tried 2048, 1500 and 1280Gb, Picked the minimum size.
